### PR TITLE
Enable for GNOME Shell 44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "name": "DashBar",
   "shell-version": [
     "42",
-    "43"
+    "43",
+    "44"
   ],
   "url": "https://github.com/fthx/dashbar",
   "uuid": "dashbar@fthx",


### PR DESCRIPTION
Per my (quick) testing, this appears to work as intended.